### PR TITLE
Attempt to fix link to repository in NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.2",
   "description": "Convert GeoJSON into Shapefile in pure JavaScript",
   "main": "index.js",
-  "repository": "git@github.com:jdesboeufs/geojson2shp.git",
+  "repository": "jdesboeufs/geojson2shp",
   "author": "Jérôme Desboeufs <jerome.desboeufs@gmail.com>",
   "license": "MIT",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.2",
   "description": "Convert GeoJSON into Shapefile in pure JavaScript",
   "main": "index.js",
-  "repository": "jdesboeufs/geojson2shp",
+  "repository": "https://github.com/jdesboeufs/geojson2shp",
   "author": "Jérôme Desboeufs <jerome.desboeufs@gmail.com>",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
Currently this package on NPM does not provide a link to GitHub:

![image](https://user-images.githubusercontent.com/20914054/91339540-03f57d80-e7ad-11ea-8f90-ed14b29d6af5.png)

I think it is due to a nonstandard way the `repository` field is filled in your package.json.

// @jdesboeufs 