### PR TITLE
Add encoding to options & create cpg file for it

### DIFF
--- a/lib/shp-write-stream/index.js
+++ b/lib/shp-write-stream/index.js
@@ -4,7 +4,7 @@ const pump = require('pump');
 const shpWritter = require('./shp');
 const DbfWritter = require('./dbf');
 class Input extends Writable {
-  constructor(schema, createStream, opts, cb) {
+  constructor(schema, createStream, opts, cb, enc) {
     super({
       objectMode: true
     });
@@ -27,6 +27,7 @@ class Input extends Writable {
     } else {
       this.schema = schema
     }
+    this.enc = enc;
     this.schema = schema;
     this.createStream = createStream;
     this.cb = cb;
@@ -92,7 +93,7 @@ class Input extends Writable {
     if (!this.schema[shpType]) {
       throw new Error('no schema for type')
     }
-    const dbf = new DbfWritter(this.schema[shpType]);
+    const dbf = new DbfWritter(this.schema[shpType], this.enc);
     const {shp, shx} = shpWritter(shpType);
     const dbfOut = this.createStream(shpType, 'dbf');
     const shpOut = this.createStream(shpType, 'shp');
@@ -143,6 +144,6 @@ class Input extends Writable {
   }
 }
 
-module.exports = function (schema, createStream, cb) {
-  return new Input(schema, createStream ,cb);
+module.exports = function (schema, createStream, cb, enc) {
+  return new Input(schema, createStream ,cb, {}, enc);
 }

--- a/lib/shp-write-stream/index.js
+++ b/lib/shp-write-stream/index.js
@@ -4,7 +4,7 @@ const pump = require('pump');
 const shpWritter = require('./shp');
 const DbfWritter = require('./dbf');
 class Input extends Writable {
-  constructor(schema, createStream, opts, cb, enc) {
+  constructor(schema, createStream, opts, cb) {
     super({
       objectMode: true
     });
@@ -27,7 +27,7 @@ class Input extends Writable {
     } else {
       this.schema = schema
     }
-    this.enc = enc;
+    this.encoding = opts.encoding;
     this.schema = schema;
     this.createStream = createStream;
     this.cb = cb;
@@ -93,7 +93,7 @@ class Input extends Writable {
     if (!this.schema[shpType]) {
       throw new Error('no schema for type')
     }
-    const dbf = new DbfWritter(this.schema[shpType], this.enc);
+    const dbf = new DbfWritter(this.schema[shpType], this.encoding);
     const {shp, shx} = shpWritter(shpType);
     const dbfOut = this.createStream(shpType, 'dbf');
     const shpOut = this.createStream(shpType, 'shp');
@@ -144,6 +144,6 @@ class Input extends Writable {
   }
 }
 
-module.exports = function (schema, createStream, cb, enc) {
-  return new Input(schema, createStream ,cb, {}, enc);
+module.exports = function (schema, createStream, options, cb) {
+  return new Input(schema, createStream, options, cb);
 }

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -25,6 +25,7 @@ function createConvertStream(options = {}) {
   const temporaryFilesPrefix = path.join(temporaryDir, id)
   const context = {}
   const layerName = options.layer || 'features'
+  const enc = options.encoding
 
   const zipFile = new ZipFile()
   const zipStream = zipFile.outputStream
@@ -76,6 +77,10 @@ function createConvertStream(options = {}) {
               zipFile.addBuffer(prjFileContent, getFileName(layerName, shpType, 'prj', writeShpType))
             }
 
+            if (extension === 'dbf' && enc && typeof enc === 'string') {
+              zipFile.addBuffer(enc.toUpperCase(), getFileName(layerName, shpType, 'cpg', writeShpType))
+            }
+
             const stream = new PassThrough()
             zipFile.addReadStream(stream, getFileName(layerName, shpType, extension, writeShpType))
             stream.write(header)
@@ -86,7 +91,8 @@ function createConvertStream(options = {}) {
 
           zipFile.end()
         }
-      }
+      },
+      enc
     )
   }
 

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -25,7 +25,7 @@ function createConvertStream(options = {}) {
   const temporaryFilesPrefix = path.join(temporaryDir, id)
   const context = {}
   const layerName = options.layer || 'features'
-  const enc = options.encoding
+  const encoding = options.encoding
 
   const zipFile = new ZipFile()
   const zipStream = zipFile.outputStream
@@ -60,6 +60,9 @@ function createConvertStream(options = {}) {
         context[`${shpType}-${extension}`] = {shpType, extension, tmpFilePath: temporaryFilePath}
         return createWriteStream(temporaryFilePath)
       },
+      {
+        encoding
+      },
       // End of processing
       (error, headers) => {
         if (error) {
@@ -77,8 +80,8 @@ function createConvertStream(options = {}) {
               zipFile.addBuffer(prjFileContent, getFileName(layerName, shpType, 'prj', writeShpType))
             }
 
-            if (extension === 'dbf' && enc && typeof enc === 'string') {
-              zipFile.addBuffer(enc.toUpperCase(), getFileName(layerName, shpType, 'cpg', writeShpType))
+            if (extension === 'dbf' && encoding && typeof encoding === 'string') {
+              zipFile.addBuffer(Buffer.from(encoding.toUpperCase()), getFileName(layerName, shpType, 'cpg', writeShpType))
             }
 
             const stream = new PassThrough()
@@ -91,8 +94,7 @@ function createConvertStream(options = {}) {
 
           zipFile.end()
         }
-      },
-      enc
+      }
     )
   }
 


### PR DESCRIPTION
In case using the 'encoding' property in the options, a 'cpg' file will be created inside the result zip with the Encoding type inside this file so programs that will use this file will detect the encoding automatically.